### PR TITLE
fix: Switch from lodash to lodash-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "prepack": "run build",
     "test": "vitest",
     "test:types": "tsc --noEmit",
-    "test:lint": "eslint . --max-warnings=0 && prettier -c ."
+    "test:lint": "prettier -c . && eslint . --max-warnings=0"
   },
   "dependencies": {
     "ajv": "^8.12.0",
@@ -105,7 +105,7 @@
     "ajv-keywords": "^5.1.0",
     "bson": "^6.2.0",
     "date-fns": "^2.21.3",
-    "lodash": "^4.17.20",
+    "lodash-es": "^4.17.21",
     "moleculer": "^0.14.33",
     "pino": "^8.20.0",
     "pino-pretty": "^11.0.0"
@@ -149,7 +149,7 @@
     "@treatwell/eslint-plugin-moleculer": "^1.1.0",
     "@tsconfig/node-lts": "^22.0.2",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/lodash": "^4.17.20",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^24.3.0",
     "@types/redlock": "^4.0.2",
     "bullmq": "^5.12.10",

--- a/src/exporters/newrelic-metrics-reporter.ts
+++ b/src/exporters/newrelic-metrics-reporter.ts
@@ -1,4 +1,4 @@
-import { defaultsDeep, isFunction } from 'lodash';
+import { defaultsDeep, isFunction } from 'lodash-es';
 import {
   MetricReporters,
   type MetricRegistry,

--- a/src/exporters/newrelic-trace-exporter.ts
+++ b/src/exporters/newrelic-trace-exporter.ts
@@ -1,4 +1,4 @@
-import { defaultsDeep, isFunction } from 'lodash';
+import { defaultsDeep, isFunction } from 'lodash-es';
 import {
   type LoggerInstance,
   type Span,

--- a/src/exporters/utils.ts
+++ b/src/exporters/utils.ts
@@ -1,5 +1,5 @@
 import type { GenericObject } from 'moleculer';
-import { isObject } from 'lodash';
+import { isObject } from 'lodash-es';
 
 /**
  * >>> Override base flattenTags function to handle objectIDs.

--- a/src/json-schema/helpers.ts
+++ b/src/json-schema/helpers.ts
@@ -1,4 +1,4 @@
-import { omit, pick } from 'lodash';
+import { omit, pick } from 'lodash-es';
 import type { JSONSchemaType, SomeJSONSchema } from './base-types.js';
 import { SCHEMA_REF_NAME } from './constants.js';
 

--- a/src/middlewares/health-check-middleware.ts
+++ b/src/middlewares/health-check-middleware.ts
@@ -3,7 +3,7 @@ import http, {
   type ServerResponse,
   STATUS_CODES,
 } from 'http';
-import { defaultsDeep } from 'lodash';
+import { defaultsDeep } from 'lodash-es';
 import type { ServiceBroker, Middleware } from 'moleculer';
 
 type HealthCheckOptions = {

--- a/src/mixins/database/indexes/index.ts
+++ b/src/mixins/database/indexes/index.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import type { Collection } from 'mongodb';
 import type { Context } from 'moleculer';
 import { wrapMixin } from '../../../types/index.js';

--- a/src/mixins/database/indexes/utils.ts
+++ b/src/mixins/database/indexes/utils.ts
@@ -1,4 +1,4 @@
-import { isEqual, isMatch } from 'lodash';
+import { isEqual, isMatch } from 'lodash-es';
 import type { Collection } from 'mongodb';
 import type { IndexTuple, MongoIndex } from './types.js';
 

--- a/src/mixins/database/restricted-fields.ts
+++ b/src/mixins/database/restricted-fields.ts
@@ -1,4 +1,4 @@
-import { omit, partition, pick } from 'lodash';
+import { omit, partition, pick } from 'lodash-es';
 
 function getFieldMode(fields: string[] | undefined): 'allow' | 'deny' {
   // Get the first field as reference (use second if first is _id)

--- a/src/mixins/queue/queue-client.mixin.ts
+++ b/src/mixins/queue/queue-client.mixin.ts
@@ -1,7 +1,7 @@
 import type { Redis } from 'ioredis';
 import { Errors } from 'moleculer';
 import { type Job, type JobsOptions, Queue, type QueueOptions } from 'bullmq';
-import { isFunction } from 'lodash';
+import { isFunction } from 'lodash-es';
 
 import { wrapMixin } from '../../types/index.js';
 import { GlobalStoreMixin } from '../global-store.mixin.js';

--- a/src/mixins/queue/queue-events-client.mixin.ts
+++ b/src/mixins/queue/queue-events-client.mixin.ts
@@ -5,7 +5,7 @@ import {
   QueueEvents,
   type QueueEventsOptions,
 } from 'bullmq';
-import { isFunction } from 'lodash';
+import { isFunction } from 'lodash-es';
 import { wrapMixin } from '../../types/index.js';
 import { GlobalStoreMixin } from '../global-store.mixin.js';
 import { createRedisConnection } from './queue-utils.js';

--- a/src/mixins/queue/queue-flow-producer.mixin.ts
+++ b/src/mixins/queue/queue-flow-producer.mixin.ts
@@ -1,6 +1,6 @@
 import { FlowProducer, type QueueBaseOptions } from 'bullmq';
 import type { Redis } from 'ioredis';
-import { isFunction } from 'lodash';
+import { isFunction } from 'lodash-es';
 import { wrapMixin } from '../../types/index.js';
 import { createRedisConnection } from './queue-utils.js';
 import type { QueueMixinOptions, WithoutConnection } from './types.js';

--- a/src/mixins/queue/queue-static-repeatable-jobs.mixin.ts
+++ b/src/mixins/queue/queue-static-repeatable-jobs.mixin.ts
@@ -1,6 +1,6 @@
 import { Queue, type RepeatOptions } from 'bullmq';
 import type { Redis } from 'ioredis';
-import { isFunction } from 'lodash';
+import { isFunction } from 'lodash-es';
 import { wrapMixin } from '../../types/index.js';
 import { GlobalStoreMixin } from '../global-store.mixin.js';
 import { createRedisConnection } from './queue-utils.js';

--- a/src/mixins/queue/queue-worker.mixin.ts
+++ b/src/mixins/queue/queue-worker.mixin.ts
@@ -1,6 +1,6 @@
 import { type Job, Worker, type WorkerOptions } from 'bullmq';
 import type { Redis } from 'ioredis';
-import { isFunction } from 'lodash';
+import { isFunction } from 'lodash-es';
 import { wrapMixin } from '../../types/index.js';
 import { createRedisConnection } from './queue-utils.js';
 import type { QueueMixinOptions, WithoutConnection } from './types.js';

--- a/src/openapi/generate-doc.ts
+++ b/src/openapi/generate-doc.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { merge } from 'lodash-es';
 import type { ServiceSchema } from 'moleculer';
 import { ZodObject, ZodOptional, ZodType } from 'zod/v4';
 import {

--- a/src/service-broker/loader.ts
+++ b/src/service-broker/loader.ts
@@ -2,7 +2,7 @@
 // the same logic used in K8S labels.
 // See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 
-import { defaultsDeep } from 'lodash';
+import { defaultsDeep } from 'lodash-es';
 import type { ServiceSchema } from 'moleculer';
 
 export type LabelValue = string;

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -11,7 +11,7 @@ import {
 } from 'moleculer';
 import addFormats from 'ajv-formats';
 import addKeywords from 'ajv-keywords';
-import { constant } from 'lodash';
+import { constant } from 'lodash-es';
 import {
   loadTransforms,
   applyBeforeTransforms,

--- a/src/validator/ref-extractor.ts
+++ b/src/validator/ref-extractor.ts
@@ -1,4 +1,4 @@
-import { isEqual, omit } from 'lodash';
+import { isEqual, omit } from 'lodash-es';
 import {
   type JSONSchemaType,
   SCHEMA_REF_NAME,

--- a/src/validator/transformers.ts
+++ b/src/validator/transformers.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, isArray } from 'lodash';
+import { isPlainObject, isArray } from 'lodash-es';
 import { CoerceArrayTransformer } from './transformers/coerce-array.js';
 import { DateTransformer } from './transformers/date.js';
 import { ObjectIdTransformer } from './transformers/object-id.js';

--- a/src/validator/transformers/coerce-array.ts
+++ b/src/validator/transformers/coerce-array.ts
@@ -1,4 +1,4 @@
-import { isArray } from 'lodash';
+import { isArray } from 'lodash-es';
 import type { Transformer, ValidationSchema } from '../types.js';
 import { LeafTransformerBase } from './leaf-transformer-base.js';
 import { COERCE_ARRAY_ATTRIBUTE } from '../../json-schema/index.js';

--- a/src/validator/transformers/date.ts
+++ b/src/validator/transformers/date.ts
@@ -1,5 +1,5 @@
 import { parseISO } from 'date-fns';
-import { isNaN, isString } from 'lodash';
+import { isNaN, isString } from 'lodash-es';
 import { LeafTransformerBase } from './leaf-transformer-base.js';
 import type { ValidationSchema, Transformer } from '../types.js';
 

--- a/src/validator/transformers/object-id.ts
+++ b/src/validator/transformers/object-id.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { isString } from 'lodash';
+import { isString } from 'lodash-es';
 import { ObjectId } from 'bson';
 import { LeafTransformerBase } from './leaf-transformer-base.js';
 import type { ValidationSchema, Transformer } from '../types.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,7 +2534,7 @@ __metadata:
     "@treatwell/eslint-plugin-moleculer": "npm:^1.1.0"
     "@tsconfig/node-lts": "npm:^22.0.2"
     "@types/jsonwebtoken": "npm:^9.0.10"
-    "@types/lodash": "npm:^4.17.20"
+    "@types/lodash-es": "npm:^4.17.12"
     "@types/node": "npm:^24.3.0"
     "@types/redlock": "npm:^4.0.2"
     ajv: "npm:^8.12.0"
@@ -2550,7 +2550,7 @@ __metadata:
     jiti: "npm:^2.5.1"
     jsonwebtoken: "npm:^9.0.2"
     jwks-rsa: "npm:^3.0.1"
-    lodash: "npm:^4.17.20"
+    lodash-es: "npm:^4.17.21"
     moleculer: "npm:^0.14.33"
     mongodb: "npm:^6.15.0"
     mongodb-memory-server: "npm:^10.2.0"
@@ -2730,7 +2730,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.17.20":
+"@types/lodash-es@npm:^4.17.12":
+  version: 4.17.12
+  resolution: "@types/lodash-es@npm:4.17.12"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10c0/5d12d2cede07f07ab067541371ed1b838a33edb3c35cb81b73284e93c6fd0c4bbeaefee984e69294bffb53f62d7272c5d679fdba8e595ff71e11d00f2601dde0
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
   version: 4.17.20
   resolution: "@types/lodash@npm:4.17.20"
   checksum: 10c0/98cdd0faae22cbb8079a01a3bb65aa8f8c41143367486c1cbf5adc83f16c9272a2a5d2c1f541f61d0d73da543c16ee1d21cf2ef86cb93cd0cc0ac3bced6dd88f
@@ -5939,7 +5948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c


### PR DESCRIPTION
Turns out NodeJS [uses](https://nodejs.org/api/esm.html#commonjs-namespaces) a heuristic to find named exports and lodash has a very complex logic for it. 
Moving to lodash-es fix this.

Note that es-modules are requirable per [this](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require)